### PR TITLE
Change `forward-addr` settings in `unbound.conf`

### DIFF
--- a/etc/unbound/unbound.conf
+++ b/etc/unbound/unbound.conf
@@ -14,6 +14,8 @@ server:
 
 forward-zone:
   name: "."
-  forward-addr: 118.89.110.78@853
-  forward-addr: 47.99.165.31@853
+  forward-addr: 1.1.1.1@853
+  forward-addr: 1.0.0.1@853
+  forward-addr: 8.8.8.8@853
+  forward-addr: 8.8.4.4@853
   forward-tls-upstream: yes


### PR DESCRIPTION
The rubyfish DNS can't resolv some domain names, e.g. `portal.shadowsocks.com`. Using Cloudflare and Google DNS can fix this problem.